### PR TITLE
Update Loopring.json with new LRC address

### DIFF
--- a/tokens/Loopring.json
+++ b/tokens/Loopring.json
@@ -1,7 +1,7 @@
 {
   "1": {
-    "0xEF68e7C694F40c8202821eDF525dE3782458639f": {
-      "address": "0xEF68e7C694F40c8202821eDF525dE3782458639f",
+    "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD": {
+      "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
       "totalSupply": "1395076054523857892274603100",
       "decimals": 18,
       "symbol": "LRC",


### PR DESCRIPTION
LRC's address has changed from 0xEF68e7C694F40c8202821eDF525dE3782458639f to 0xEF68e7C694F40c8202821eDF525dE3782458639f (lrctoken.eth)

More details: https://medium.com/loopring-protocol/lrc-token-upgraded-a26ee6f87b84